### PR TITLE
fix(docker-compose): links are deprecated, instead use networks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,9 +10,6 @@ services:
     hostname: yulmails
     networks:
       - yulmails
-    links:
-      - workdb:workdb
-      - archivingdb:archivingdb
     ports:
       - "${YMAILS_IP_LISTENING:-127.0.0.1}:${YMAILS_PORT_LISTENING:-80}:80"
     volumes:


### PR DESCRIPTION
I removed `links` in `docker-compose.yaml` because of this functionality is deprecated.

```
-    links:
-      - workdb:workdb
-      - archivingdb:archivingdb
```

Note that now you should use `networks` instead. If you give a name to your containers that allows you to use the `container_name` value in a container to communicate with others containers.

Here our container is named `yulmails` and we want that it can communicate with `workdb` - another container providing a nosql database service.

```
    container_name: yulmails
    hostname: yulmails
    networks:
      - yulmails
```

The `workdb` container is configured to run in the same network than `yulmails`. So, inside `yulmails` container we can resolve `workdb` name.


```
docker-compose exec yulmails ping -c1 workdb
PING workdb (172.30.0.3): 56 data bytes
64 bytes from 172.30.0.3: seq=0 ttl=64 time=0.168 ms

--- workdb ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.168/0.168/0.168 ms
```

Hope that might helps.