### PR TITLE
feat(compose): yulmails config file in a shared volume in read-only

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - "${YMAILS_IP_LISTENING:-127.0.0.1}:${YMAILS_PORT_LISTENING:-80}:80"
     volumes:
       - "${YMAILS_VOLUMES_LOGS:-/var/log/}:/var/log/:rw"
+      - "./yulmails.yaml:/etc/yulmails/yulmails.yaml:ro"
       
   workdb:
     image: mongo:3.6.1


### PR DESCRIPTION
I modified `docker-compose.yaml` to  share `yulmails.yaml` config file in read-only. :+1: 

If you want to only share one file instead of a directory, you must create the file before you run the container. If the file doesn't exist before you run the container, then Docker will create a directory. :expressionless:

From the[ official Docker documentation](https://docs.docker.com/engine/admin/volumes/bind-mounts/#differences-between--v-and---mount-behavior) :

> If you use -v or --volume to bind-mount a file or directory that does not yet exist on the Docker host, -v creates the endpoint for you. **It is always created as a directory**.

