### PR TITLE
update documentation & fix docker compose build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.6"
 
 services:
   nginx:
@@ -14,6 +14,9 @@ services:
 
   yulmails-api:
     image: registry.local.tld/yulmails:develop
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: yulmails-api
     hostname: yulmails-api
     volumes:
@@ -22,6 +25,9 @@ services:
 
   yulmails-sender:
     image: registry.local.tld/yulmails:develop
+    build:  
+      context: .
+      dockerfile: Dockerfile
     container_name: yulmails-sender
     hostname: yulmails-sender
     command: yulmails sender
@@ -29,7 +35,10 @@ services:
       - "${YMAILS_VOLUMES_LOGS:-/var/log/}:/var/log/:rw"
 
   yulmails-compute:
-    image: registry.local.tld/yulmails:query-redis
+    image: registry.local.tld/yulmails:develop
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: yulmails-compute
     hostname: yulmails-compute
     command: yulmails compute
@@ -37,7 +46,10 @@ services:
       - "${YMAILS_VOLUMES_LOGS:-/var/log/}:/var/log/:rw"
 
   yulmails-entrypoint:
-    image: registry.local.tld/yulmails:query-redis
+    image: registry.local.tld/yulmails:develop
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: yulmails-entrypoint
     hostname: yulmails-entrypoint
     command: yulmails entrypoint
@@ -62,11 +74,6 @@ services:
     image: redis:3.2.11-alpine
     container_name: redis
     hostname: redis
-
-networks:
-  default:
-    external:
-      name: net-yulmails
 
 volumes:
   database_data: {}

--- a/swagger.json
+++ b/swagger.json
@@ -307,14 +307,10 @@
     "Options": {
       "properties": {
         "quota": {
-          "items": {
-            "$ref": "#/definitions/OptionsQuota"
-          }
+          "$ref": "#/definitions/OptionsQuota"
         },
         "conservation": {
-          "items": {
-            "$ref": "#/definitions/OptionsConservation"
-          }
+          "$ref": "#/definitions/OptionsConservation"
         }
       }
     },


### PR DESCRIPTION
Now you can build as described in the doc: 

```shell
$ docker-compose build 
```
And swagger documentation has been updated following `options` type object.
