### PR TITLE
ci: add gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,45 @@
+image: golang:1.13.1
+
+variables:
+  REPO_NAME: github.com/yulpa/yulmails
+
+before_script:
+  - mkdir -p $GOPATH/src/$(dirname $REPO_NAME)
+  - ln -svf $CI_PROJECT_DIR $GOPATH/src/$REPO_NAME
+  - cd $GOPATH/src/$REPO_NAME
+
+stages:
+  - test
+  - build
+
+test:
+  stage: test
+  script:
+    - go test -race $(go list ./...)
+
+docker-build-master:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE" .
+    - docker push "$CI_REGISTRY_IMAGE"
+  only:
+    - master
+
+docker-build:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - master
+

--- a/services/sender/main_test.go
+++ b/services/sender/main_test.go
@@ -76,7 +76,7 @@ VGVsbCBtZSwgdGVtcHRlciwgd2hhdCBkbyB5b3UgaGF2ZSBpbiB5b3VyIHBhbnRzPw0KSXMgaXQg
 		},
 	}
 	for _, test := range tests {
-		recipients, err := listRecipients(test.mail)
+		recipients, _ := listRecipients(test.mail)
 		assert.Equal(t, test.recipients, len(recipients))
 	}
 }


### PR DESCRIPTION
In waiting for a dedicated CI/CD service. I added Gitlab CI integration.

Pipelines are [here](https://gitlab.com/TortueMat/yulmails/pipelines). You'll need to ask for permissions.

steps are: 

- run go tests
- build / push docker image